### PR TITLE
fix: pin the source artifact's content hash in the clean-control resume gate

### DIFF
--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -108,12 +108,18 @@ retroactively rewritten.
 Long runs save after every case (atomic replace) and support `--resume`, so an
 interrupted multi-hour run is not lost. `--resume` refuses to append when
 `config_detail`, `search`, `profile`, `generation_sha256_16` or `prompts_sha256_16` differ
-from the existing file, so results from different code never mix into one record.
+from the existing file, so results from different code never mix into one record. For the
+clean-English control, `config_detail` also pins the source artifact's **content hash**,
+not just its `source_tag` filename (schema 3, #47). Filename-only pinning let a
+regenerated actual arm pass the gate, and the resulting file — half built from the old
+KO→EN text, half from the new — still satisfied `check_provenance` downstream, because a
+run records a single source sha. The refusal now happens in `init_payloads`, before any
+model loads.
 
 The committed clean-control outputs are complete legacy schema-1 records. At generation
 time the alias table lived inside `control_clean_english.py`, so the recorded script hash
-covered it. They must not be resumed with the schema-2 harness or backfilled with the
-current alias-file hash. Their raw stage records also retain a legacy `stopped_at_cap`
+covered it. They must not be resumed with a later-schema harness or backfilled with the
+current alias-file or source hashes — neither can be re-derived. Their raw stage records also retain a legacy `stopped_at_cap`
 field derived from post-generation retokenization; it is not a recorded stop reason and
 must not be interpreted as one. Current runs write `retokenized_near_limit` instead.
 

--- a/eval/issue-43-proper-noun-corruption/control_clean_english.py
+++ b/eval/issue-43-proper-noun-corruption/control_clean_english.py
@@ -69,11 +69,14 @@ EXPECTED_CALLS = 24
 
 # 1 = alias table inlined in this script, so script_sha256_16 covered it.
 # 2 = alias table lives in canonical_aliases.py and is hashed separately.
-# Records written under schema 1 cannot be upgraded: the hash that would prove which
-# alias table they used is the old script hash, and that script no longer exists on
-# disk. Backfilling today's aliases_sha256_16 would assert something unverified, so a
-# schema-1 record is refused with an explanation instead.
-CONFIG_DETAIL_SCHEMA = 2
+# 3 = the source artifact's content hash is carried, not just its filename. Schema 2
+#     pinned source_tag only, so regenerating the actual arm and resuming appended
+#     results built from a different KO->EN input to results built from the old one,
+#     and the mixed file still passed check_provenance downstream (it records one sha).
+# An older record cannot be upgraded: the hash that would prove which inputs it used was
+# never written. Backfilling today's value would assert something unverified, so the
+# record is refused with an explanation instead.
+CONFIG_DETAIL_SCHEMA = 3
 
 def load_cases():
     cases = [json.loads(l) for l in open(f"{HERE}/cases.jsonl") if l.strip()]
@@ -178,12 +181,16 @@ def build_config_detail(reasoner):
     """Provenance that must match for a resume to be allowed.
 
     run.RESUME_KEYS covers search/profile/generation/prompts hashes but knows nothing
-    about this experiment's own inputs, so the script, alias data and question set are
-    carried here — check_resumable compares config_detail as a whole.
+    about this experiment's own inputs, so the script, alias data, question set and
+    source artifact are carried here — check_resumable compares config_detail as a whole.
+
+    source_tag alone is a filename and says nothing about content: regenerating the
+    actual arm leaves it unchanged, so the source hash is what actually gates a resume.
     """
     return dict(experiment=EXPERIMENT, reasoner=reasoner, profile=PROFILE,
                 config_detail_schema=CONFIG_DETAIL_SCHEMA,
                 source_tag=SOURCE_TAG,
+                source_sha256_16=file_sha16(f"{HERE}/outputs/{reasoner}/{SOURCE_TAG}"),
                 script_sha256_16=file_sha16(f"{HERE}/control_clean_english.py"),
                 aliases_sha256_16=file_sha16(f"{HERE}/canonical_aliases.py"),
                 questions_sha256_16=file_sha16(f"{HERE}/control_questions.jsonl"))
@@ -208,12 +215,14 @@ def init_payloads(env, resume):
                         f"{os.path.relpath(d, HERE)} was written under config_detail "
                         f"schema {prev.get('config_detail_schema', 1)}; this script writes "
                         f"schema {CONFIG_DETAIL_SCHEMA}.\n"
-                        "    Schema 1 inlined the alias table in the script, so its "
-                        "script_sha256_16 covered the aliases; schema 2 hashes\n"
-                        "    canonical_aliases.py separately. The schema-1 hash cannot be "
-                        "re-derived, so resuming would silently mix\n"
-                        "    two different alias tables. If the run is already complete no "
-                        "resume is needed; otherwise start a fresh run.")
+                        "    Schema 1 inlined the alias table in the script; schema 2 "
+                        "hashes canonical_aliases.py separately; schema 3\n"
+                        "    additionally pins the source artifact's content, not just "
+                        "its filename. The missing hashes cannot be\n"
+                        "    re-derived, so resuming would silently mix two different "
+                        "alias tables or two different KO->EN sources.\n"
+                        "    If the run is already complete no resume is needed; "
+                        "otherwise start a fresh run.")
             if not resume:
                 raise SystemExit(
                     f"refusing to overwrite {os.path.relpath(d, HERE)}\n"

--- a/eval/issue-43-proper-noun-corruption/test_control_preflight.py
+++ b/eval/issue-43-proper-noun-corruption/test_control_preflight.py
@@ -151,6 +151,43 @@ def _():
     assert cd["questions_sha256_16"] == C.file_sha16(f"{C.HERE}/control_questions.jsonl")
 
 
+@check("config_detail pins the source artifact's content, not just its filename")
+def _():
+    for name in C.REASONERS:
+        cd = C.build_config_detail(name)
+        assert cd["source_sha256_16"] == C.file_sha16(
+            f"{C.HERE}/outputs/{name}/{C.SOURCE_TAG}"), name
+    # Distinct arms read distinct sources; one shared hash would defeat the check.
+    assert len({C.build_config_detail(n)["source_sha256_16"] for n in C.REASONERS}) == \
+        len(C.REASONERS)
+
+
+@check("init_payloads: a regenerated source artifact is refused on --resume")
+def _():
+    env = fresh_env()
+    with tempfile.TemporaryDirectory() as tmp:
+        saved, C.OUT_ROOT = C.OUT_ROOT, tmp
+        try:
+            p = C.init_payloads(env, resume=False)
+            for name in C.REASONERS:
+                R.save(C.dest_path(name), p[name])
+            # Same source_tag, different content — exactly what regenerating the actual
+            # arm produces. Schema 2 pinned only the filename and let this through.
+            real_sha = C.file_sha16
+            C.file_sha16 = lambda p: ("cafebabecafebabe" if p.endswith(C.SOURCE_TAG)
+                                      else real_sha(p))
+            try:
+                C.init_payloads(env, resume=True)
+            except SystemExit as e:
+                assert "config_detail" in str(e), e
+                return
+            finally:
+                C.file_sha16 = real_sha
+            raise AssertionError("resume accepted a different source artifact")
+        finally:
+            C.OUT_ROOT = saved
+
+
 @check("init_payloads: fresh run creates empty per-reasoner payloads")
 def _():
     env = fresh_env()


### PR DESCRIPTION
Closes #47. Found in the 4-reviewer round on #45; surfaced by the Codex reviewer.

## Problem

`build_config_detail()` recorded `source_tag` — a filename — but not the content hash of
the artifact it copies KO→EN text from. `run.RESUME_KEYS` does not cover it either, so
regenerating `outputs/three-stage-*/run-search-off-production.json` and then running
`control_clean_english.py --resume` was accepted: the filename was unchanged, every
compared key matched, and the resumed half of the run was built from different inputs
than the first half.

The downstream net does not catch this. `analyze_transitions.check_provenance()` compares
the control's recorded `source_artifacts` sha against the artifact on disk, but a resumed
run records a single sha — so an internally-mixed file compares equal and passes. The
mixture is undetectable after the fact, and 24 model calls have already been spent.

## Change

`config_detail` now carries `source_sha256_16` per reasoner, and `CONFIG_DETAIL_SCHEMA`
goes 2 → 3. `check_resumable` already compares `config_detail` as a whole, so a changed
source is refused without touching the resume machinery. The refusal happens in
`init_payloads`, before the first `R.load()`.

Older records are refused rather than upgraded, for the same reason schema 1 was: the
hash that would prove which source they used was never written, and backfilling today's
value would assert something unverified.

## Verification

```
test_score.py             17/17 passed
test_control_preflight.py 26/26 passed   (24 -> 26, both new)
test_transitions.py       22/22 passed
--dry-run                 leakage PASS, budget 24/24, one prompt sha per case
git diff --check          clean
```

The two new tests are discriminating, not decorative — with `source_sha256_16` removed
from `build_config_detail`, the suite drops to 24/26 with exactly those two failing:

```
FAIL  config_detail pins the source artifact's content, not just its filename
FAIL  init_payloads: a regenerated source artifact is refused on --resume
```

The second test drives the real `init_payloads` with a stubbed hash for the source file
only, so it exercises the actual refusal path rather than re-implementing it.