### PR TITLE
fix: make the leakage and truncation guards in the #43 harness able to fire

### DIFF
--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -15,7 +15,7 @@ regression-tested rather than assumed to work.
 | `run.py` | Runs a configuration, capturing **every stage** and full environment metadata. |
 | `score.py` | Canonical recall (automatic) + entity validity (annotation-driven). |
 | `isolate.py` | Three controlled experiments separating translation / reasoner / back-translation. |
-| `control_questions.jsonl` | Hand-written English questions with the same intent and no canonical-name leakage. |
+| `control_questions.jsonl` | Hand-written English questions with the same intent and no canonical-name leakage (Hangul, listed aliases, and RR across spacing/hyphenation; non-RR romanizations rest on the alias table — #49). |
 | `control_clean_english.py` | Runs the clean-English reasoner + back-translation control at production limits. |
 | `analyze_transitions.py` | Compares per-person reasoner (R) to final translation (T) transitions without model calls. |
 | `canonical_aliases.py` | Canonical alias data and the boundary-aware matcher, shared by the control harness and the analyzer. |

--- a/eval/issue-43-proper-noun-corruption/analyze_transitions.py
+++ b/eval/issue-43-proper-noun-corruption/analyze_transitions.py
@@ -85,9 +85,24 @@ def korea_cases():
     return [c for c in non_holdout_cases() if c["domain"] == "korea"]
 
 
-def unterminated(stage):
-    """No closing marker means the model never left its reasoning block."""
-    return not CLOSURE.search(stage["raw"])
+def emits_closure(results):
+    """Whether this reasoner marks the end of its reasoning at all, in this run.
+
+    A missing closure only means truncation for a model that writes one when it finishes.
+    run.py:has_unterminated_think() uses an opened block as its precondition, but that
+    cannot be reused here: Qwen3.6's chat template opens <think> in the prompt, so the
+    opener is absent from every completion including the genuinely truncated ones. What
+    does separate them is that their siblings closed and they did not — so require the
+    reasoner to have closed at least once before reading a missing marker as truncation.
+    Without this, adding a reasoner that emits no reasoning block would silently drop all
+    of its cases from SENSITIVITY on both arms.
+    """
+    return any(CLOSURE.search(r["stages"]["reason"]["raw"]) for r in results)
+
+
+def unterminated(stage, emits_closure=True):
+    """No closing marker from a reasoner that does emit them: it never left the block."""
+    return emits_closure and not CLOSURE.search(stage["raw"])
 
 
 def near_limit(stage, limit):
@@ -137,10 +152,11 @@ def collect():
         a_e_lim = aenv["generation"]["translate_max_tokens"]
         c_r_lim = cenv["generation"]["reason_max_tokens"]
         c_e_lim = cenv["generation"]["translate_max_tokens"]
+        a_emits, c_emits = emits_closure(A.values()), emits_closure(C.values())
         for c in korea_cases():
             a, b = A[c["id"]], C[c["id"]]
-            a_un = unterminated(a["stages"]["reason"])
-            c_un = unterminated(b["stages"]["reason"])
+            a_un = unterminated(a["stages"]["reason"], a_emits)
+            c_un = unterminated(b["stages"]["reason"], c_emits)
             meta[(reasoner, c["id"])] = dict(
                 actual_unterminated=a_un, control_unterminated=c_un,
                 closed_pair=not (a_un or c_un),

--- a/eval/issue-43-proper-noun-corruption/canonical_aliases.py
+++ b/eval/issue-43-proper-noun-corruption/canonical_aliases.py
@@ -72,6 +72,17 @@ def romanize(text):
     return "".join(out)
 
 
+def romanize_spaced(text):
+    """Mechanical romanization with syllable boundaries kept as spaces.
+
+    romanize() alone yields one fused token ("sinsukju"), and contains_alias compiles a
+    single-part alias to a bare literal — so the leakage guard only ever matched a
+    spelling no English text uses. Spacing the syllables lets the same _NAME_SEP logic
+    that serves conventional aliases cover "Sin Sukju", "Sin Suk-ju" and "Sinsukju" too.
+    """
+    return " ".join(romanize(ch) for ch in text if "가" <= ch <= "힣")
+
+
 def flat_letters(text):
     """Lowercase, ASCII letters only. Not used by contains_alias, which is word-bounded;
     only for controlled comparisons of short fixed strings in diagnostics and preflight.

--- a/eval/issue-43-proper-noun-corruption/control_clean_english.py
+++ b/eval/issue-43-proper-noun-corruption/control_clean_english.py
@@ -18,8 +18,11 @@ The KO2EN stage is never re-called; its text is copied from the production artif
 purely for the record.
 
 Design constraints enforced in code, not by convention:
-  - clean questions carry no canonical person name, in Hangul or romanized (verified at
-    load; see check_no_leakage)
+  - clean questions carry no canonical person name, in Hangul, in any listed conventional
+    alias, or in Revised Romanization across spacing and hyphenation (verified at load;
+    see check_no_leakage). Romanizations that are not RR-derived — McCune-Reischauer
+    "Sin Suk-chu" for 신숙주, say — are covered only by CONVENTIONAL_ALIASES, which is
+    hand-maintained; check_alias_coverage proves it is non-empty per person, not complete.
   - both reasoners receive a byte-identical system+user prompt per case, recorded as
     prompt_sha256_16
   - production profile only (reason 4000 / translate 2000)
@@ -59,7 +62,7 @@ sys.path.insert(0, HERE)
 
 import run as R  # reuse call/save/env_metadata/profiles; importing loads no model
 from canonical_aliases import (CONVENTIONAL_ALIASES, contains_alias,
-                               flat_letters as _flat, romanize)
+                               flat_letters as _flat, romanize, romanize_spaced)
 
 EXPERIMENT = "control-clean-english"
 PROFILE = "production"
@@ -113,7 +116,9 @@ def check_no_leakage(cases, questions):
                 if contains_alias(q, alias):
                     problems.append((c["id"], f"conventional alias {e} -> {alias!r}"))
             rom = romanize(e)
-            if len(rom) >= 5 and contains_alias(q, rom):
+            # Spaced so syllables match across spacing and hyphenation; the length floor
+            # stays on the fused form, keeping very short names (이익 -> "iik") out.
+            if len(rom) >= 5 and contains_alias(q, romanize_spaced(e)):
                 problems.append((c["id"], f"mechanical romanization {e} ({rom})"))
     return problems
 

--- a/eval/issue-43-proper-noun-corruption/test_control_preflight.py
+++ b/eval/issue-43-proper-noun-corruption/test_control_preflight.py
@@ -130,6 +130,34 @@ def _():
         assert any(C._flat(a) == C._flat(alias) for a in C.CONVENTIONAL_ALIASES[ko]), ko
 
 
+@check("the romanization leakage arm matches spacing and hyphenation, not one fused token")
+def _():
+    # The fused form is a spelling no English question would contain, so matching only it
+    # made this arm of check_no_leakage unable to fire.
+    rom, spaced = C.romanize("신숙주"), C.romanize_spaced("신숙주")
+    assert rom == "sinsukju" and spaced == "sin suk ju", (rom, spaced)
+    for q in ("compiled by Sin Suk-ju", "compiled by Sin Sukju",
+              "compiled by Sinsukju", "compiled by SIN SUK JU"):
+        assert C.contains_alias(q, spaced), q
+        assert not C.contains_alias(q, rom) or q.endswith("Sinsukju"), q
+    # Still word-bounded: a longer name must not be swallowed.
+    assert not C.contains_alias("compiled by Sin Suk-ju-hwan", spaced)
+
+
+@check("check_no_leakage rejects a question carrying a spaced mechanical romanization")
+def _():
+    cases = C.load_cases()
+    questions = dict(C.load_questions())
+    cid = cases[0]["id"]
+    victim = next(e for c in cases for e in c["canonical_people"]
+                  if len(C.romanize(e)) >= 5)
+    questions[cid] = f"What did {C.romanize_spaced(victim).title()} contribute?"
+    problems = C.check_no_leakage(cases, questions)
+    assert any(i == cid and "mechanical romanization" in w for i, w in problems), problems
+    # The shipped question set must remain clean.
+    assert not C.check_no_leakage(cases, C.load_questions())
+
+
 @check("production profile only: reason 4000 / translate 2000")
 def _():
     p = R.PROFILES[C.PROFILE]

--- a/eval/issue-43-proper-noun-corruption/test_transitions.py
+++ b/eval/issue-43-proper-noun-corruption/test_transitions.py
@@ -58,6 +58,35 @@ def _():
     assert not A.unterminated({"raw": "analysis assistantfinal answer"})
 
 
+@check("a reasoner that never closes at all is not read as truncated")
+def _():
+    # Qwen3.6 opens <think> from the chat template, so the opened-block precondition
+    # run.py uses is absent from every completion — including the genuinely truncated
+    # ones, which must stay flagged. The separating signal is the arm's own behaviour.
+    closing = [{"stages": {"reason": {"raw": "a </think> b"}}},
+               {"stages": {"reason": {"raw": "mid-sentence and cut"}}}]
+    never = [{"stages": {"reason": {"raw": "plain answer"}}},
+             {"stages": {"reason": {"raw": "another plain answer"}}}]
+    assert A.emits_closure(closing) and not A.emits_closure(never)
+    cut = {"raw": "mid-sentence and cut"}
+    assert A.unterminated(cut, A.emits_closure(closing)), "truncation must stay flagged"
+    assert not A.unterminated(cut, A.emits_closure(never)), \
+        "a non-reasoning model's every case would be dropped from SENSITIVITY"
+
+
+@check("the two real truncated Qwen3.6 stages have no opener, so run.py's test cannot be reused")
+def _():
+    rows, meta = A.collect()
+    for cfg, tag, cid in (("three-stage-qwen36", A.ACTUAL_TAG, "ko-03"),
+                          ("control-clean-qwen36", A.CONTROL_TAG, "ko-04")):
+        raw = A.load_arm(cfg, tag)[0][cid]["stages"]["reason"]["raw"]
+        assert "<think>" not in raw and "<|channel|>analysis" not in raw, cid
+        assert not A.CLOSURE.search(raw), cid
+    # Mirroring run.py's precondition literally would unflag both and erase SENSITIVITY.
+    assert meta[("qwen36", "ko-03")]["actual_unterminated"] is True
+    assert meta[("qwen36", "ko-04")]["control_unterminated"] is True
+
+
 @check("near_limit is retokenized-length semantics, not a recorded stop reason")
 def _():
     assert A.near_limit({"tokens": 4000}, 4000)


### PR DESCRIPTION
Closes #49. Both guards were written correctly in intent but could not fire as documented.
No figure changes: 16/42, 12/42, and sensitivity n=28 at 71.43% → 80.00% all reproduce.

## 1. Mechanical-romanization leakage

`romanize()` emits one fused token and `_alias_pattern()` compiles a single-part alias to
a bare literal, so this arm of `check_no_leakage` only matched `sinsukju` — a spelling no
English question contains.

`romanize_spaced()` keeps syllable boundaries, so the same `_NAME_SEP` logic that already
serves conventional aliases now covers spacing and hyphenation:

```
by Sin Suk-ju    -> True      by Sinsukju  -> True
by Sin Sukju     -> True      by SIN SUK JU -> True
by Sin Suk-ju-hwan -> False   (still word-bounded)
```

**Honest limit:** this does not cover the original review example. McCune-Reischauer
`Sin Suk-chu` has `chu` where RR has `ju`, so it still returns False and remains the
alias table's job. The module docstring claimed questions are verified free of canonical
names "in Hangul or romanized"; it and the README now state what is actually enforced —
RR across spacing/hyphenation, with non-RR forms resting on the hand-maintained
`CONVENTIONAL_ALIASES`, which `check_alias_coverage` proves non-empty per person, not
complete.

## 2. Reason-block termination

`unterminated()` read a missing closing marker as truncation unconditionally, so adding a
reasoner that emits no reasoning block would have dropped every one of its cases from
SENSITIVITY on both arms.

**The obvious fix is wrong and I did not apply it.** The review suggested mirroring
`run.py:has_unterminated_think()`'s opened-block precondition. Checking the artifacts
first:

```
three-stage-qwen36   ko-03  open=False close=False tokens=4000  head="Here's a thinking process:..."
control-clean-qwen36 ko-04  open=False close=False tokens=3998  head="Here's a thinking process:..."
```

Qwen3.6 opens `<think>` from the chat template, so the opener is absent from every
completion — including both genuinely truncated stages. Mirroring `run.py` would unflag
them and erase the sensitivity analysis. What separates a truncated stage is that its
siblings closed and it did not, so `emits_closure()` requires the arm to have closed at
least once before a missing marker counts.

## Verification

```
test_score.py             17/17 passed
test_control_preflight.py 28/28 passed   (26 -> 28)
test_transitions.py       24/24 passed   (22 -> 24)
--dry-run                 leakage PASS, budget 24/24
git diff --check          clean
score.py                  16/42, 12/42          — unchanged
analyze_transitions.py    n=28, 71.43% -> 80.00% — unchanged
```

Reverting each fix in place fails the matching test, so the behavioural pair is
discriminating:

```
FAIL  check_no_leakage rejects a question carrying a spaced mechanical romanization
FAIL  a reasoner that never closes at all is not read as truncated
```

The other two added tests are invariant guards rather than change detectors: one unit-tests
`romanize_spaced`, and one pins the two real truncated stages as still-flagged, documenting
why `run.py`'s precondition cannot be reused here.