### PR TITLE
fix: deny the particle rule for homograph-prone canonical entries

### DIFF
--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -246,6 +246,17 @@ from `7aeb6d9` and the current scorer on the unchanged JSON produced 15→16 for
 and 9→12 for Qwen3.6. The difference comes from `def8942`, which admits attached Korean
 particles and titles in canonical matching; it is not a generation improvement.
 
+Five canonical entries are excluded from the particle rule and match only bare or with a
+title (`score.PARTICLE_AMBIGUOUS`, #48): `이익` also means "profit", `심정` "feelings",
+`인종` "race", `정선` is a county and "carefully selected", and `황진` + the subject
+particle 이 spells `황진이`, the poet — a different real person. The rule costs nothing
+on these runs, since each of them is also named bare in the same answer, and it gives up
+the general's own subject form `황진이` because that string is genuinely ambiguous.
+
+It does not cover bare-string homonyms. `최항` is both the Goryeo military ruler 崔沆 and
+the Joseon Hall-of-Worthies scholar 崔恒; no surface rule separates them, so a model that
+confuses the two still scores a hit. `test_score.py` pins this rather than hiding it.
+
 ### Candidate vs production, same configurations
 
 | Configuration | Profile | Recall | Avg latency (Korea) |

--- a/eval/issue-43-proper-noun-corruption/score.py
+++ b/eval/issue-43-proper-noun-corruption/score.py
@@ -66,6 +66,25 @@ def _alt(words):
 # A title and a particle stack: 세종대왕의. Both optional, and a non-Hangul boundary is
 # still required after them.
 NAME_SUFFIX = rf"(?:{_alt(TITLES)})?(?:{_alt(PARTICLES)})?"
+TITLE_SUFFIX = rf"(?:{_alt(TITLES)})?"
+
+# Canonical entries whose spelling is also ordinary vocabulary, or becomes a different
+# real person once a particle attaches. A particle-suffixed match cannot be told apart
+# from 이익 "profit", 심정 "feelings", 인종 "race", 정선 (Jeongseon county / 精選), or from
+# the poet 황진이 — 황진 ends in a consonant, so 이 is the only correct subject particle
+# and "황진이" is exactly the poet's name. For these, only the bare or title-bearing form
+# counts. This costs no recall on the committed runs: each of them is also named bare in
+# the same answer, verified before the rule was added.
+#
+# Deliberately not a general fix. 최항 is a bare-string homonym — the Goryeo military
+# ruler 崔沆 and the Joseon Hall-of-Worthies scholar 崔恒 — and no surface rule separates
+# those, so era confusion still scores as a hit.
+PARTICLE_AMBIGUOUS = frozenset({"이익", "심정", "인종", "정선", "황진"})
+
+
+def canonical_pattern(entity):
+    suffix = TITLE_SUFFIX if entity in PARTICLE_AMBIGUOUS else NAME_SUFFIX
+    return rf"(?<![가-힣]){re.escape(entity)}{suffix}(?![가-힣])"
 
 
 def plausible_name(tok):
@@ -90,9 +109,12 @@ def find_canonical(text, canon):
     title (see NAME_SUFFIX). Requiring a bare non-Hangul boundary rejected
     성삼문과, 김종직의 and 세종대왕, and it did so unevenly across configurations,
     so the gap between them was overstated as well as the absolute numbers.
+
+    Entities in PARTICLE_AMBIGUOUS take the title-only suffix instead: for those
+    the particle form is indistinguishable from ordinary vocabulary or from a
+    different real person.
     """
-    return {e for e in canon
-            if re.search(rf"(?<![가-힣]){re.escape(e)}{NAME_SUFFIX}(?![가-힣])", text)}
+    return {e for e in canon if re.search(canonical_pattern(e), text)}
 
 
 def extract_people(text):

--- a/eval/issue-43-proper-noun-corruption/test_score.py
+++ b/eval/issue-43-proper-noun-corruption/test_score.py
@@ -10,7 +10,8 @@ import os, sys
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from score import find_canonical
 
-CANON = ["세종", "성삼문", "김종직", "연산군", "이익", "김부식", "정약용", "원균"]
+CANON = ["세종", "성삼문", "김종직", "연산군", "이익", "김부식", "정약용", "원균",
+         "황진", "심정", "인종", "최항"]
 
 # (text, expected matches, why)
 CASES = [
@@ -30,6 +31,27 @@ CASES = [
     ("박영호가 참여했다", set(), "unrelated surface form"),
     ("세종실록에 기록되어", set(), "실록 is not a particle or title — compound work name"),
     ("원균형제", set(), "형제 is not in the suffix list"),
+
+    # --- PARTICLE_AMBIGUOUS: the particle form is not attributable (#48) ---
+    ("**황진이**, **유자광**", set(), "황진이 is the poet, a different real person"),
+    ("백성의 이익을 위해", set(), "이익 here is the common noun 'profit'"),
+    ("학자들의 심정을 이해", set(), "심정 here is the common noun 'feelings'"),
+    ("다양한 인종이 공존했다", set(), "인종 here is the common noun 'race'"),
+    # ...but the bare and title-bearing forms still count for the same entities
+    ("**이익 (1681-1764)**", {"이익"}, "bare name with dates"),
+    ("이익(영남 학파)", {"이익"}, "bare name, parenthetical gloss"),
+    ("인종(재위 1122-1146)은 왕권을", {"인종"}, "bare name, reign dates"),
+    ("황진 장군이 진주성을 지켰다", {"황진"}, "title 장군 still attaches"),
+    ("황진, 이억기, 정운", {"황진"}, "bare name in a list"),
+    # The cost of the rule, pinned so it is not mistaken for a bug later: the general's
+    # own subject form is 황진이, indistinguishable from the poet, so it is given up.
+    ("황진이 이끄는 부대가 진주성을 지켰다", set(),
+     "genuine 황진 + subject 이 is sacrificed — same string as the poet"),
+    # A bare-string homonym is out of reach of any suffix rule, and the deny-list must
+    # not be described as covering it: the Goryeo ruler 崔沆 scores as the Joseon
+    # scholar 崔恒 either way. Pinned so the limitation stays visible.
+    ("최항이 무신정권을 장악했다", {"최항"}, "era confusion still scores — 崔沆 vs 崔恒"),
+    ("최항, 집현전 학자", {"최항"}, "bare 최항 counts, as it must"),
 
     # --- unchanged behaviour ---
     ("이순신과 원균", {"원균"}, "plain particle case, 이순신 not in CANON"),


### PR DESCRIPTION
Closes #48. Deny-list approach, per the decision to keep canonical recall a fully
automatic metric rather than routing ambiguous matches to human annotation.

## Change

`score.PARTICLE_AMBIGUOUS` = `{이익, 심정, 인종, 정선, 황진}`. These match bare or with a
title only; the particle rule from `def8942` no longer applies to them.

| Entity | Colliding reading |
|---|---|
| `이익` | 利益 "profit" — and ko-01's topic is Silhak economic reform |
| `심정` | 心情 "feelings" |
| `인종` | 人種 "race" |
| `정선` | Jeongseon county / 精選 "carefully selected" |
| `황진` | + subject particle 이 spells `황진이`, the poet — a different real person |

```
백성의 이익을 위해        -> {}        (was {'이익'})
학자들의 심정을 이해       -> {}        (was {'심정'})
다양한 인종이 공존했다      -> {}        (was {'인종'})
**황진이**, **유자광**   -> {}        (was {'황진'})

**이익 (1681-1764)**   -> {'이익'}   bare with dates, still counts
이익(영남 학파)           -> {'이익'}
인종(재위 1122-1146)은   -> {'인종'}
황진 장군이 진주성을        -> {'황진'}   title 장군 still attaches
```

## No figure moves

Checked *before* writing the rule: every `PARTICLE_AMBIGUOUS` entity that currently hits
is also named bare somewhere in the same answer, so set membership is untouched.

```
score.py --tag search-off-production          16/42, 12/42   unchanged
score.py --tag control-clean-english-production 19/42, 15/42 unchanged
analyze_transitions.py   84.21 / 82.61 / 63.16 / 78.95%, sensitivity n=28  unchanged
```

## Two limits, pinned in tests rather than papered over

**The general's own subject form is sacrificed.** 황진 ends in a consonant, so 이 is the
only grammatical subject particle — `황진이 이끄는 부대` is correct Korean for "the unit
Hwang Jin led", and it is character-identical to the poet's name. That case now scores 0.
`test_score.py` asserts it, labelled as a deliberate cost.

**Bare-string homonyms are out of reach.** `최항` is both the Goryeo military ruler 崔沆
and the Joseon Hall-of-Worthies scholar 崔恒. No suffix rule separates them, so a model
that confuses the eras still scores a hit. Asserted as `{'최항'}` so the limitation stays
visible instead of being read as coverage.

## Verification

```
test_score.py             29/29 passed   (17 -> 29)
test_control_preflight.py 28/28 passed
test_transitions.py       24/24 passed
git diff --check          clean
```

Emptying `PARTICLE_AMBIGUOUS` drops the suite to 24/29 with exactly the five new
behavioural cases failing, so they are change detectors, not decoration.