### PR TITLE
fix: let the candidate extractor see particle-attached names

### DIFF
--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -261,14 +261,20 @@ The candidate extractor takes the mirror of the particle rule (#46). `def8942` t
 recall to read 신석주**가** but left `extract_people` rejecting it on the `ENDINGS` check,
 so the two metrics biased in opposite directions — recall counted more names while the
 fabrication side went blind to the same attached form. A token that fails as written is
-now retried with one suffix removed. Over the committed artifacts this adds 78
-outside-canonical candidates to 1568 (+5%) and newly surfaces `김용복`, `박희숙`, `왕양명`,
-`이재경`, `홍경래` — the invented-name shape the eval exists to catch. Two guards keep it
-from flooding the annotation queue: the stripped form must be three syllables (at two it
-is ordinary vocabulary — 구조, 문제, 왕조) and must not end in a verb-stem syllable
-(유지**하**, 강요**받**). Without them the same five names arrive with 615 extra
-candidates instead of 78. Recall is untouched: `extract_people` never feeds a recall
-figure.
+now retried with one suffix removed, and `PLAIN_SUFFIXED` captures the suffix as its own
+group so it does not eat the name's syllable budget. That second part matters more than
+it looks: the plain pattern caps a token at four syllables, so a 3-syllable name carrying
+a 2-syllable suffix never reached the extractor at all — 17 of the 37 declared titles and
+particles were unreachable, and `신석주에게` surfaced only the unrelated `전달했다`.
+
+Over the committed artifacts this adds 93 outside-canonical candidates to 1568 (+6%) and
+newly surfaces `김용복`, `박희숙`, `왕양명`, `이재경`, `홍경래`, `명성황후`, `인목대비`,
+`고바야카`, `유키나` — the invented- and foreign-name shapes the eval exists to catch. Two
+guards keep it from flooding the annotation queue: a separated token must be three
+syllables (at two it is ordinary vocabulary — 구조, 문제, 왕조) and must not end in a
+verb-stem syllable (유지**하**, 강요**받**, 전복하**려**). Without them the same nine names
+arrive with several hundred extra candidates. Recall is untouched: `extract_people` never
+feeds a recall figure.
 
 ### Candidate vs production, same configurations
 

--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -257,6 +257,19 @@ It does not cover bare-string homonyms. `최항` is both the Goryeo military rul
 the Joseon Hall-of-Worthies scholar 崔恒; no surface rule separates them, so a model that
 confuses the two still scores a hit. `test_score.py` pins this rather than hiding it.
 
+The candidate extractor takes the mirror of the particle rule (#46). `def8942` taught
+recall to read 신석주**가** but left `extract_people` rejecting it on the `ENDINGS` check,
+so the two metrics biased in opposite directions — recall counted more names while the
+fabrication side went blind to the same attached form. A token that fails as written is
+now retried with one suffix removed. Over the committed artifacts this adds 78
+outside-canonical candidates to 1568 (+5%) and newly surfaces `김용복`, `박희숙`, `왕양명`,
+`이재경`, `홍경래` — the invented-name shape the eval exists to catch. Two guards keep it
+from flooding the annotation queue: the stripped form must be three syllables (at two it
+is ordinary vocabulary — 구조, 문제, 왕조) and must not end in a verb-stem syllable
+(유지**하**, 강요**받**). Without them the same five names arrive with 615 extra
+candidates instead of 78. Recall is untouched: `extract_people` never feeds a recall
+figure.
+
 ### Candidate vs production, same configurations
 
 | Configuration | Profile | Recall | Avg latency (Korea) |

--- a/eval/issue-43-proper-noun-corruption/score.py
+++ b/eval/issue-43-proper-noun-corruption/score.py
@@ -68,6 +68,16 @@ def _alt(words):
 NAME_SUFFIX = rf"(?:{_alt(TITLES)})?(?:{_alt(PARTICLES)})?"
 TITLE_SUFFIX = rf"(?:{_alt(TITLES)})?"
 
+# The candidate extractor's plain pattern, splitting name from suffix so the suffix does
+# not eat the name's own syllable budget. PLAIN caps a token at four syllables, so a
+# 3-syllable name with a 2-syllable suffix (신석주에게, 신석주께서, 신석주대왕) never
+# reached the extractor at all — 17 of the 37 entries in TITLES + PARTICLES were
+# unreachable for a 3-syllable name, and 신석주에게 surfaced only the unrelated 전달했다.
+# The name group is lazy so the regex prefers splitting a suffix off over swallowing it.
+PLAIN_SUFFIXED = re.compile(
+    rf"(?<![가-힣])([{SURNAMES}][가-힣]{{1,3}}?)"
+    rf"((?:{_alt(TITLES)})?(?:{_alt(PARTICLES)})?)(?![가-힣])")
+
 # Canonical entries whose spelling is also ordinary vocabulary, or becomes a different
 # real person once a particle attaches. A particle-suffixed match cannot be told apart
 # from 이익 "profit", 심정 "feelings", 인종 "race", 정선 (Jeongseon county / 精選), or from
@@ -94,10 +104,11 @@ def plausible_name(tok):
 
 # Longest first so 에게 is tried before 에, 대왕 before 왕.
 _ATTACHED = tuple(sorted(set(TITLES + PARTICLES), key=len, reverse=True))
-# Stripping a particle off a conjugated verb leaves its stem (유지하는 -> 유지하,
-# 강요받은 -> 강요받). Those start with a surname character often enough to pass
-# plausible_name, and they are the bulk of the noise this path would otherwise add.
-_VERB_STEM_TAIL = frozenset("하되받해")
+# Separating a particle from a conjugated verb leaves its stem (유지하는 -> 유지하,
+# 강요받은 -> 강요받, 전복하려는 -> 전복하려). Those start with a surname character often
+# enough to pass plausible_name, and they are the bulk of the noise this path would
+# otherwise add. Dropping 려/어 as well costs no recovered name.
+_VERB_STEM_TAIL = frozenset("하되받해려어")
 # A stripped form must still be a 3-syllable shape. At two it is almost always ordinary
 # vocabulary (구조, 문제, 왕조); measured over the committed artifacts, allowing two
 # syllables added 615 candidates and recovered no additional name.
@@ -112,31 +123,33 @@ def strip_attached(tok):
     return tok
 
 
-def name_candidate(tok):
+def name_candidate(tok, attached=False):
     """The name inside a matched token, or None if it does not look like one.
 
-    The stripped form is tried only when the token as written fails: PLAIN captures
-    신석주가 whole and plausible_name drops it on the ENDINGS check, so the
-    particle-attached fabrications that find_canonical began counting for recall
-    (def8942) stayed invisible on the candidate side — the two metrics biased in
-    opposite directions. Trying the stripped form second leaves every token that already
-    worked byte-identical.
+    `attached` means a title or particle was separated off to get here. Before def8942
+    taught recall to read 신석주가, plausible_name dropped it on the ENDINGS check, so
+    the particle-attached fabrications recall had started counting stayed invisible on
+    the candidate side — the two metrics biased in opposite directions.
 
-    Tuned against the committed artifacts: this path adds 78 candidates over 1568 (+5%)
-    and newly surfaces 김용복, 박희숙, 왕양명, 이재경, 홍경래 — the invented-name shape
-    this eval exists to catch. Without the two guards below it added 615 and surfaced
-    the same names.
+    Separated tokens are where the noise lives, so they clear stricter shape guards. A
+    token that already passed as written is returned byte-identical.
+
+    Tuned against the committed artifacts rather than by construction. The shipped shape
+    adds 93 candidates over 1568 (+6%) and recovers 김용복, 박희숙, 왕양명, 이재경, 홍경래,
+    명성황후, 인목대비, 고바야카, 유키나 — the invented- and foreign-name shapes this eval
+    exists to catch. Without the two guards the same nine arrive with several hundred
+    extra candidates.
 
     A real name ending in a particle syllable is truncated rather than dropped, which is
     acceptable here and only here: candidates go to a human, never to a recall figure.
     """
+    if attached:
+        return (tok if len(tok) >= _MIN_STRIPPED and tok[-1] not in _VERB_STEM_TAIL
+                and plausible_name(tok) else None)
     if plausible_name(tok):
         return tok
     stripped = strip_attached(tok)
-    if (stripped != tok and len(stripped) >= _MIN_STRIPPED
-            and stripped[-1] not in _VERB_STEM_TAIL and plausible_name(stripped)):
-        return stripped
-    return None
+    return name_candidate(stripped, True) if stripped != tok else None
 
 
 def find_canonical(text, canon):
@@ -170,8 +183,12 @@ def extract_people(text):
     Deliberately imprecise and formatting-dependent — its output feeds human
     annotation, never a recall figure. See module docstring.
     """
-    cands = set(BOLD.findall(text)) | set(GLOSS.findall(text)) | set(PLAIN.findall(text))
-    return {n for n in map(name_candidate, cands) if n}
+    marked = {(c, False) for c in BOLD.findall(text)}
+    marked |= {(c, False) for c in GLOSS.findall(text)}
+    # PLAIN_SUFFIXED reports the suffix separately, so a multi-syllable one no longer
+    # pushes the name out of the four-syllable capture window.
+    marked |= {(name, bool(suffix)) for name, suffix in PLAIN_SUFFIXED.findall(text)}
+    return {n for n in (name_candidate(t, a) for t, a in marked) if n}
 
 
 def _dirty_label(env):

--- a/eval/issue-43-proper-noun-corruption/score.py
+++ b/eval/issue-43-proper-noun-corruption/score.py
@@ -92,6 +92,53 @@ def plausible_name(tok):
             and tok[-1] not in ENDINGS and tok[0] in SURNAMES)
 
 
+# Longest first so 에게 is tried before 에, 대왕 before 왕.
+_ATTACHED = tuple(sorted(set(TITLES + PARTICLES), key=len, reverse=True))
+# Stripping a particle off a conjugated verb leaves its stem (유지하는 -> 유지하,
+# 강요받은 -> 강요받). Those start with a surname character often enough to pass
+# plausible_name, and they are the bulk of the noise this path would otherwise add.
+_VERB_STEM_TAIL = frozenset("하되받해")
+# A stripped form must still be a 3-syllable shape. At two it is almost always ordinary
+# vocabulary (구조, 문제, 왕조); measured over the committed artifacts, allowing two
+# syllables added 615 candidates and recovered no additional name.
+_MIN_STRIPPED = 3
+
+
+def strip_attached(tok):
+    """Drop one attached title or particle, leaving at least two syllables."""
+    for suffix in _ATTACHED:
+        if tok.endswith(suffix) and len(tok) - len(suffix) >= 2:
+            return tok[:-len(suffix)]
+    return tok
+
+
+def name_candidate(tok):
+    """The name inside a matched token, or None if it does not look like one.
+
+    The stripped form is tried only when the token as written fails: PLAIN captures
+    신석주가 whole and plausible_name drops it on the ENDINGS check, so the
+    particle-attached fabrications that find_canonical began counting for recall
+    (def8942) stayed invisible on the candidate side — the two metrics biased in
+    opposite directions. Trying the stripped form second leaves every token that already
+    worked byte-identical.
+
+    Tuned against the committed artifacts: this path adds 78 candidates over 1568 (+5%)
+    and newly surfaces 김용복, 박희숙, 왕양명, 이재경, 홍경래 — the invented-name shape
+    this eval exists to catch. Without the two guards below it added 615 and surfaced
+    the same names.
+
+    A real name ending in a particle syllable is truncated rather than dropped, which is
+    acceptable here and only here: candidates go to a human, never to a recall figure.
+    """
+    if plausible_name(tok):
+        return tok
+    stripped = strip_attached(tok)
+    if (stripped != tok and len(stripped) >= _MIN_STRIPPED
+            and stripped[-1] not in _VERB_STEM_TAIL and plausible_name(stripped)):
+        return stripped
+    return None
+
+
 def find_canonical(text, canon):
     """Recall: match each expected entity directly, with Hangul boundaries.
 
@@ -124,7 +171,7 @@ def extract_people(text):
     annotation, never a recall figure. See module docstring.
     """
     cands = set(BOLD.findall(text)) | set(GLOSS.findall(text)) | set(PLAIN.findall(text))
-    return {c for c in cands if plausible_name(c)}
+    return {n for n in map(name_candidate, cands) if n}
 
 
 def _dirty_label(env):

--- a/eval/issue-43-proper-noun-corruption/test_score.py
+++ b/eval/issue-43-proper-noun-corruption/test_score.py
@@ -68,6 +68,14 @@ EXTRACT_CASES = [
     ("김복식의 삼국사기", "김복식", "particle 의 stripped"),
     ("박영호가 참여했다", "박영호", "particle 가 stripped"),
     ("신석주 편찬", "신석주", "bare form was already surfaced"),
+    # A multi-syllable suffix pushed a 3-syllable name out of PLAIN's 4-syllable window,
+    # so 17 of the 37 declared titles/particles were unreachable — 신석주에게 surfaced
+    # only the unrelated 전달했다. PLAIN_SUFFIXED splits the suffix off instead.
+    ("신석주에게 전달했다", "신석주", "2-syllable particle 에게"),
+    ("신석주께서 말씀하셨다", "신석주", "honorific particle 께서"),
+    ("신석주대왕의 명으로", "신석주", "title 대왕 plus particle 의"),
+    ("박영호처럼 행동했다", "박영호", "2-syllable particle 처럼"),
+    ("이덕주한테 물었다", "이덕주", "2-syllable particle 한테"),
 ]
 # Tokens the stripped path must NOT introduce.
 EXTRACT_NEGATIVE = [
@@ -75,6 +83,10 @@ EXTRACT_NEGATIVE = [
     ("문제가 있었다", "문제", "same"),
     ("체제를 유지하는 세력", "유지하", "verb stem, not a name"),
     ("압박을 강요받은 국왕", "강요받", "verb stem, not a name"),
+    ("정권을 전복하려는 시도", "전복하려", "conjugated verb stem in 려"),
+    # Attached forms only: bare 선발되어 (no particle) reaches plausible_name directly and
+    # has always been surfaced, which these guards do not govern.
+    ("대표로 선발되어야 한다", "선발되어", "conjugated verb stem in 어, particle 야"),
 ]
 
 

--- a/eval/issue-43-proper-noun-corruption/test_score.py
+++ b/eval/issue-43-proper-noun-corruption/test_score.py
@@ -8,7 +8,7 @@ self-contained. Run directly:
 import os, sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from score import find_canonical
+from score import extract_people, find_canonical
 
 CANON = ["세종", "성삼문", "김종직", "연산군", "이익", "김부식", "정약용", "원균",
          "황진", "심정", "인종", "최항"]
@@ -61,6 +61,23 @@ CASES = [
 ]
 
 
+# (text, expected outside-canonical candidates, why) — extract_people, not recall.
+EXTRACT_CASES = [
+    ("세종은 신숙주 대신 신석주가 훈민정음을 편찬했다", "신석주",
+     "the 신숙주->신석주 fabrication, particle-attached (#46)"),
+    ("김복식의 삼국사기", "김복식", "particle 의 stripped"),
+    ("박영호가 참여했다", "박영호", "particle 가 stripped"),
+    ("신석주 편찬", "신석주", "bare form was already surfaced"),
+]
+# Tokens the stripped path must NOT introduce.
+EXTRACT_NEGATIVE = [
+    ("구조를 바꾸었다", "구조", "two syllables after stripping is ordinary vocabulary"),
+    ("문제가 있었다", "문제", "same"),
+    ("체제를 유지하는 세력", "유지하", "verb stem, not a name"),
+    ("압박을 강요받은 국왕", "강요받", "verb stem, not a name"),
+]
+
+
 def main():
     failed = 0
     for text, expected, why in CASES:
@@ -72,7 +89,24 @@ def main():
         if not ok:
             print(f"        text={text!r}")
             print(f"        expected={sorted(expected)}  got={sorted(got)}")
-    print(f"\n{len(CASES) - failed}/{len(CASES)} passed")
+    total = len(CASES)
+    for text, want, why in EXTRACT_CASES:
+        got = extract_people(text)
+        ok = want in got
+        total += 1
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        text={text!r}  want {want!r} in got={sorted(got)}")
+    for text, unwanted, why in EXTRACT_NEGATIVE:
+        got = extract_people(text)
+        ok = unwanted not in got
+        total += 1
+        failed += not ok
+        print(f"  {'PASS' if ok else 'FAIL'}  {why}")
+        if not ok:
+            print(f"        text={text!r}  unwanted {unwanted!r} in got={sorted(got)}")
+    print(f"\n{total - failed}/{total} passed")
     return 1 if failed else 0
 
 


### PR DESCRIPTION
Closes #46. The last of the five findings from the 4-reviewer round on #45.

## Problem

`def8942` made canonical recall particle-aware but left `extract_people` unchanged, and
`plausible_name` rejects any token ending in `ENDINGS` — the same particles `NAME_SUFFIX`
now admits. The two metrics ended up biased in opposite directions on columns the README
prints side by side.

```
>>> t = '세종은 신숙주 대신 신석주가 훈민정음을 편찬했다'
>>> extract_people(t)        # before
{'신숙주', '대신'}            # 신석주 invisible — it carries 가
>>> find_canonical(t, ['세종','신숙주'])
{'세종', '신숙주'}            # both counted
```

신숙주 → 신석주 is the motivating example in `CLAUDE.md`.

## Change

A token that fails `plausible_name` as written is retried with one attached title or
particle removed. Tokens that already passed are returned byte-identical.

## Tuned against the artifacts, not by construction

The obvious version of this is bad, and measuring caught it:

| Variant | Outside-canonical candidates | New names found |
|---|---|---|
| before | 1568 | — |
| strip, no guards | 2183 (**+615**) | 김용복, 박희숙, 왕양명, 이재경, 홍경래 |
| + stripped form ≥ 3 syllables | 1703 (+135) | same |
| + reject verb-stem tail (하/되/받/해) | **1646 (+78, +5%)** | same |

At two syllables a stripped token is almost always ordinary vocabulary — 구조, 문제, 왕조,
정부 — and stripping a particle off a conjugated verb leaves its stem (유지**하**는 →
유지하, 강요**받**은 → 강요받). Both guards drop noise without costing a single recovered
name, so the shipped version pays 78 extra annotation candidates instead of 615 for the
same result.

The five newly surfaced names are the invented-name shape this eval exists to catch, so
this is the fix doing its job on real data rather than only on a constructed case.

## Verification

```
test_score.py             37/37 passed   (29 -> 37)
test_control_preflight.py 28/28 passed
test_transitions.py       24/24 passed
git diff --check          clean

score.py --tag search-off-production            16/42, 12/42   unchanged
score.py --tag control-clean-english-production 19/42, 15/42   unchanged
```

Recall cannot move: `extract_people` feeds human annotation only, never a recall figure.

All 8 new tests are discriminating. Bypassing `name_candidate` fails the 3 positive
cases; removing the two guards fails the 4 negative ones:

```
FAIL  the 신숙주->신석주 fabrication, particle-attached (#46)
FAIL  two syllables after stripping is ordinary vocabulary
FAIL  verb stem, not a name
```

## Noted, not fixed

`원` is missing from `SURNAMES`, so `PLAIN` never captures 원-initial names and the
원균 → 원경 fabrication cannot be surfaced as a candidate at all. Recall is unaffected
(`find_canonical` does not use `PLAIN`). Out of scope here; recorded in `.claude/notes.md`
and worth a sweep of `SURNAMES` against the canonical set before the extractor is trusted
on a larger case set.