### PR TITLE
docs: close two doc/code consistency gaps found in a sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ python3 multimodal.py --no-search "이 주장을 분석해줘"
 - Qwen 번역은 기능적 수준 (전문 번역가 수준은 아님, 하지만 의미 전달 충분)
 - 최초 실행 시 모델 다운로드 필요 (~73GB)
 - GPT-OSS는 한국어 네이티브가 아님 → 삼단 구조(번역 래퍼) 필수
+- **한국 인명이 포함된 질문은 번역 왕복에서 실존하지 않는 인물명이 만들어질 수 있음** — 누락이 아니라 날짜까지 붙은 그럴듯한 가짜 이름으로 대체됨(신숙주→신석주, 원균→원경). 실측 recall 16/42(38.1%). Korea 도메인 답변은 검증 없이 신뢰하지 말 것 ([#43](https://github.com/WoojinAhn/local-llm-pipeline/issues/43), 하네스: `eval/issue-43-proper-noun-corruption/`)
 - ~~Ollama는 M5 Max Metal 크래시 이슈로 사용 불가~~ → `brew install --cask ollama`로 설치 시 정상 동작 확인 ([ollama#14432](https://github.com/ollama/ollama/issues/14432))
 
 ### LM Studio 버전 (레거시)
@@ -379,6 +380,7 @@ Text-to-image / image-to-image generation via a native MLX Swift implementation 
 - Qwen translation is functional, not professional-grade (but sufficient for comprehension)
 - First run downloads ~73GB of model weights
 - GPT-OSS is not Korean-native → triple-stage (translation wrapper) is required
+- **Queries involving Korean personal names can come back with people who never existed** — the round trip does not drop a name, it substitutes a plausible one, sometimes with dates (신숙주 → 신석주, 원균 → 원경). Measured recall is 16/42 (38.1%). Do not trust Korea-domain answers without checking them ([#43](https://github.com/WoojinAhn/local-llm-pipeline/issues/43), harness under `eval/issue-43-proper-noun-corruption/`)
 - ~~Ollama unusable on M5 Max due to Metal crash~~ → works with `brew install --cask ollama` (pre-built binary) ([ollama#14432](https://github.com/ollama/ollama/issues/14432))
 
 ### LM Studio Version (Legacy)

--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -21,6 +21,9 @@ regression-tested rather than assumed to work.
 | `canonical_aliases.py` | Canonical alias data and the boundary-aware matcher, shared by the control harness and the analyzer. |
 | `annotations.jsonl` | Human verdicts on entities the models produced. |
 | `outputs/` | Raw run records. |
+| `test_score.py` | Scorer: canonical matching, the homograph deny-list, candidate extraction. All three suites load no model. |
+| `test_control_preflight.py` | Control harness: call budget, leakage guard, resume and provenance refusals. |
+| `test_transitions.py` | Alias matcher and analyzer aggregates, checked against the committed artifacts. |
 
 ## The two metrics are not interchangeable
 


### PR DESCRIPTION
Closes #56, closes #57. Both found by checking documented claims against the code and the
committed artifacts rather than by reading the docs.

## #56 — the README never mentioned the #43 limitation

`CLAUDE.md` carries an explicit warning ("Do not treat Korea-domain answers from the
3-stage path as reliable"). `README.md` had nothing:

```
grep -n "고유명사|proper noun|날조|fabricat|#43|신숙주" README.md   -> no match
```

Both Limitations sections listed milder items instead — harmony latency, "Qwen
translation is functional, not professional-grade", the ~73GB download. The
agent-facing doc said do-not-trust while the human-facing doc, which is what someone
reads before using the pipeline, was silent. The omission ran in the direction that
flatters the project.

Added one bullet to `제한 사항` and its counterpart in `Limitations`, keeping the KO/EN
parity the README convention requires (6 bullets each, verified). The wording states the
failure mode rather than a score: the round trip does not drop a name, it substitutes a
plausible one, sometimes with dates.

## #57 — the harness file table omitted every test file

The table is the directory inventory, but `test_score.py` appeared only once in prose and
`test_control_preflight.py` / `test_transitions.py` were absent from the README entirely.
Three rows added.

## Verification

```
KO bullets 6 / EN bullets 6                  parity held
issues/43 links in README                    2 (one per side)
3 table rows present, 3 files exist on disk  yes
git diff --check                             clean
```

Docs-only; no code touched. The rest of the sweep found no mismatch — CLAUDE.md's key
files (7/7), named functions (6/6), model IDs (3/3), CLI flags (6/6) and interactive
commands (9/9) all match the code, the harness README's figures reproduce on master
(16/42, 12/42, 19/42, 15/42 and the full transition table), and no knowledge file under
`~/home/` references this project.