### PR TITLE
fix: admit 민/원 as surnames and sweep SURNAMES against the case set

### DIFF
--- a/eval/issue-43-proper-noun-corruption/README.md
+++ b/eval/issue-43-proper-noun-corruption/README.md
@@ -280,6 +280,16 @@ verb-stem syllable (유지**하**, 강요**받**, 전복하**려**). Without the
 arrive with several hundred extra candidates. Recall is untouched: `extract_people` never
 feeds a recall figure.
 
+`SURNAMES` gates that whole path, and a missing entry fails silently — no error, the name
+simply is never a candidate. `민` and `원` were both absent (#55), so `민영익`, `원균` and
+any corruption of them were unreachable; `원균`'s corruption `원경` sits in
+`three-stage-qwen36` ko-03 and had never been surfaced. Admitting the two surnames also
+admits ordinary words starting with them (민족, 원칙 …), so the observed ones went to
+`STOPWORDS`: +10 candidates over 1661, against `원경` becoming visible. `test_score.py`
+now sweeps `cases.jsonl` and fails if any canonical person's initial is missing, with
+regnal and dharma names (세종, 중종, 각훈, 일연) listed as the only legitimate exceptions —
+a new case with an unlisted surname breaks a test instead of going quietly invisible.
+
 ### Candidate vs production, same configurations
 
 | Configuration | Profile | Recall | Avg latency (Korea) |

--- a/eval/issue-43-proper-noun-corruption/score.py
+++ b/eval/issue-43-proper-noun-corruption/score.py
@@ -28,8 +28,14 @@ from collections import Counter
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
+# A missing surname fails silently: the extractor raises nothing, the name is simply
+# never a candidate. test_score.py sweeps this against cases.jsonl so a new canonical
+# entry with an unlisted surname breaks a test instead of going quietly invisible. 민/원
+# were found missing that way — 원균's corruption 원경 sits in a committed artifact and
+# was unreachable. #55
 SURNAMES = ("김이박최정강조윤장임한오서신권황안송류유전홍고문양손배백허남심노하"
-            "곽성차주우구석선설마길연방위표명기반왕금옥육인맹제모탁국여진어편봉대걸")
+            "곽성차주우구석선설마길연방위표명기반왕금옥육인맹제모탁국여진어편봉대걸"
+            "민원")
 # Inflectional endings — a Korean given name never ends in these.
 ENDINGS = set("을를이가은는의에서로와과도만고며여다한할함들적성화기인된대라며야죠음임든지네요")
 STOPWORDS = {
@@ -40,6 +46,10 @@ STOPWORDS = {
     "농업", "토지", "군사", "국방", "외교", "재정", "세금", "신분제", "훈구파", "사림파", "북학파",
     "개화파", "실학", "정음", "이두", "표기", "연구", "학파", "계열", "중인", "상민", "천민",
     "방법론", "정통성", "연대기", "왕조사", "편찬자", "표기법", "문화권", "한국어", "국학의",
+    # Admitting 민/원 as surnames (#55) also admits these ordinary words. Observed in the
+    # committed artifacts, not guessed.
+    "민간", "민담", "민병", "민속", "민족", "민중", "원래", "원리", "원본", "원산", "원천",
+    "원칙", "원주민",
 }
 BOLD = re.compile(r"\*\*([가-힣]{2,4})\*\*")
 GLOSS = re.compile(r"([가-힣]{2,4})\s*\(\s*[一-鿿]{2,4}\s*\)")

--- a/eval/issue-43-proper-noun-corruption/test_score.py
+++ b/eval/issue-43-proper-noun-corruption/test_score.py
@@ -3,12 +3,20 @@
 Plain asserts, no test framework — the repo has no test suite and this harness is
 self-contained. Run directly:
 
-    python eval/issue-43-proper-noun-corruption/test_score.py
+    .venv/bin/python eval/issue-43-proper-noun-corruption/test_score.py
 """
-import os, sys
+import json, os, sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import score
 from score import extract_people, find_canonical
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Canonical entries that legitimately carry no surname: regnal names and dharma names.
+# Everything else must start with a listed surname or the extractor can never surface it
+# — nor any corruption of it, which is the whole point of the candidate side. #55
+NOT_SURNAME_BEARING = {"세종", "중종", "각훈", "일연"}
 
 CANON = ["세종", "성삼문", "김종직", "연산군", "이익", "김부식", "정약용", "원균",
          "황진", "심정", "인종", "최항"]
@@ -68,6 +76,10 @@ EXTRACT_CASES = [
     ("김복식의 삼국사기", "김복식", "particle 의 stripped"),
     ("박영호가 참여했다", "박영호", "particle 가 stripped"),
     ("신석주 편찬", "신석주", "bare form was already surfaced"),
+    # 원 was missing from SURNAMES, so 원균's corruption sat in a committed artifact
+    # (three-stage-qwen36 ko-03) and could never be surfaced. #55
+    ("이순신(주요 장군), 원경(초기, 후에 처형됨)", "원경", "surname 원 (#55)"),
+    ("민영직이 참여했다", "민영직", "surname 민 (#55)"),
     # A multi-syllable suffix pushed a 3-syllable name out of PLAIN's 4-syllable window,
     # so 17 of the 37 declared titles/particles were unreachable — 신석주에게 surfaced
     # only the unrelated 전달했다. PLAIN_SUFFIXED splits the suffix off instead.
@@ -102,6 +114,29 @@ def main():
             print(f"        text={text!r}")
             print(f"        expected={sorted(expected)}  got={sorted(got)}")
     total = len(CASES)
+
+    # Sweep, not a patch: every canonical person must be reachable by the extractor.
+    unreachable = []
+    for line in open(f"{HERE}/cases.jsonl"):
+        if not line.strip():
+            continue
+        c = json.loads(line)
+        if c["domain"] != "korea":
+            continue
+        for person in c["canonical_people"]:
+            if person in NOT_SURNAME_BEARING:
+                continue
+            if person[0] not in score.SURNAMES:
+                unreachable.append(f"{c['id']}:{person} (initial {person[0]!r})")
+    total += 1
+    ok = not unreachable
+    failed += not ok
+    print(f"  {'PASS' if ok else 'FAIL'}  every canonical person's surname is in SURNAMES")
+    if not ok:
+        print(f"        unreachable by extract_people: {unreachable}")
+        print(f"        add the surname to score.SURNAMES, or list a non-surname "
+              f"entry in NOT_SURNAME_BEARING")
+
     for text, want, why in EXTRACT_CASES:
         got = extract_people(text)
         ok = want in got


### PR DESCRIPTION
Closes #55. The last open finding from the review sweep.

## Problem

`SURNAMES` gates the whole candidate-extraction path, and a missing entry fails silently
— no error, the name simply is never a candidate. Sweeping it against `cases.jsonl`, six
canonical entities had an initial outside the list:

```
각훈  세종  일연  중종      regnal / dharma names — correctly excluded
민영익  원균              민 and 원 are real surnames — a plain gap
```

`원균 → 원경` is one of the two fabrications `CLAUDE.md` names as the motivating defect
for #43. It has been sitting in a committed artifact the whole time, unreachable:

```
three-stage-qwen36 ko-03:
  ... 이순신(주요 장군), 원경(초기, 후에 처형됨), 이연, 이완, 김용식, 김장환 ...
```

## Change

Added `민` and `원`. That also admits ordinary words starting with them, so the ones
actually observed in the artifacts went to `STOPWORDS` — observed, not guessed:

| | candidates | new distinct |
|---|---|---|
| before | 1661 | — |
| +민원 | 1708 (+47) | 19, mostly 민족 / 원칙 / 원리 … |
| **+STOPWORDS** | **1671 (+10)** | **6, including 원경** |

+0.6% for making the named fabrication visible.

## Fixed as a sweep, not a patch

Per the issue, `test_score.py` now walks `cases.jsonl` and fails if any canonical
person's initial is missing from `SURNAMES`. Regnal and dharma names (세종, 중종, 각훈,
일연) are the only listed exceptions, so a new case with an unlisted surname breaks a test
instead of going quietly invisible — which is the actual failure mode here.

## Verification

```
test_score.py             47/47 passed   (44 -> 47)
test_control_preflight.py 28/28 passed
test_transitions.py       24/24 passed
git diff --check          clean
recall 16/42, 12/42, 19/42, 15/42   unchanged
```

Recall cannot move — `extract_people` feeds human annotation only.

All three new tests discriminate. Removing `민원` from `SURNAMES` again:

```
FAIL  every canonical person's surname is in SURNAMES
FAIL  surname 원 (#55)
FAIL  surname 민 (#55)
```